### PR TITLE
Fix Aspire launch settings structure

### DIFF
--- a/aspire/CarvedRock-Aspire.AppHost/Properties/launchSettings.json
+++ b/aspire/CarvedRock-Aspire.AppHost/Properties/launchSettings.json
@@ -1,17 +1,16 @@
 {
   "$schema": "https://json.schemastore.org/launchsettings.json",
   "profiles": {
-      "Aspire": {
-        "commandName": "Project",
-        "dotnetRunMessages": true,
-        "launchBrowser": true,
-        "applicationUrl": "https://localhost:17276",
-        "environmentVariables": {
-          "ASPNETCORE_ENVIRONMENT": "Development",
-          "DOTNET_ENVIRONMENT": "Development",
-          "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21202",
-          "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22145"
-        }
+    "Aspire": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17276",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21202",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22145"
       }
     }
   }


### PR DESCRIPTION
The extra closing bracket didn't allow launch settings to be properly used for startup